### PR TITLE
Electron version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,13 @@ build:
 	@$(MAKE) _assemble BUILD_TYPE=4 VER=_ STEM=basiced_type4
 	@$(MAKE) _assemble BUILD_TYPE=0 "VER=$(VER)" STEM=basiced
 	@$(MAKE) _assemble BUILD_TYPE=1 "VER=$(VER)" STEM=hibasiced
+	@$(MAKE) _assemble BUILD_TYPE=8 "VER=$(VER)" STEM=elkbasiced
+	@$(MAKE) _assemble BUILD_TYPE=9 "VER=$(VER)" STEM=elkhibasiced
 
 	@$(MAKE) _copy STEM=basiced DRIVE=$(DRIVE) BBC=R.BETOM
 	@$(MAKE) _copy STEM=hibasiced DRIVE=$(DRIVE) BBC=R.HBETOM
+	@$(MAKE) _copy STEM=elkbasiced DRIVE=$(DRIVE) BBC=R.EBETOM
+	@$(MAKE) _copy STEM=elkhibasiced DRIVE=$(DRIVE) BBC=R.EHBETOM
 	@$(MAKE) _copy STEM=basiced_type4 DRIVE=$(DRIVE) BBC=R.BE4TOM
 
 	@python tools/checksize.py $(DEST)/basiced_.rom $(DEST)/basiced.rom $(DEST)/hibasiced.rom

--- a/basiced.s65
+++ b/basiced.s65
@@ -15,8 +15,10 @@ wordv=$20c
 ; BUILD_TYPE==2: Relocatable ($8000 version)
 ; BUILD_TYPE==3: Relocatable ($b800 version)
 ; BUILD_TYPE==4: assembled at $3800, for testing routines from BASIC
+; BUILD_TYPE==8: Electron
+; BUILD_TYPE==9: Electron HI (untested)
 
-; Only build types 0 and 1 are valid ROMs!
+; Only build types 0+1 and 8+9 are valid ROMs!
 
 HI_ADDRESS = $b800
 
@@ -24,6 +26,7 @@ HI_ADDRESS = $b800
                 
 RELOCATABLE: = false
 HI: = false
+ELECTRON: = false
 SVC_BASE: = $8000
 LANG_BASE: = $8000
 
@@ -31,6 +34,7 @@ LANG_BASE: = $8000
                 
 RELOCATABLE: = false
 HI: = true
+ELECTRON: = false
 SVC_BASE: = $8000
 LANG_BASE: = HI_ADDRESS
                 
@@ -38,6 +42,7 @@ LANG_BASE: = HI_ADDRESS
                 
 RELOCATABLE: = true
 HI: = false
+ELECTRON: = false
 SVC_BASE: = $8000
 LANG_BASE: = $8000
 
@@ -45,6 +50,7 @@ LANG_BASE: = $8000
                 
 RELOCATABLE: = true
 HI: = false
+ELECTRON: = false
 SVC_BASE: = $8000
 LANG_BASE: = HI_ADDRESS
 
@@ -52,12 +58,29 @@ LANG_BASE: = HI_ADDRESS
 
 RELOCATABLE: = false
 HI: = false
+ELECTRON:= false
 
 ; the ROM ought to fit (at least, in Mode 7...) starting from $3c00,
 ; but the TOC and/or extra debug junk might push the size past 16K.
 SVC_BASE: = $3800
 LANG_BASE:= $3800   
-                
+
+                .elsif BUILD_TYPE==8
+
+RELOCATABLE: = false
+HI: = false
+ELECTRON: = true
+SVC_BASE: = $8000
+LANG_BASE: = $8000
+
+                .elsif BUILD_TYPE==9
+
+RELOCATABLE: = false
+HI: = true
+ELECTRON: = true
+SVC_BASE: = $8000
+LANG_BASE: = HI_ADDRESS
+
                 .endif
 
 ;-------------------------------------------------------------------------

--- a/cmds.s65
+++ b/cmds.s65
@@ -1,3 +1,7 @@
+.if !ELECTRON
+
+; BBC Micro key layout
+;
 ; Commands are bound to keys by giving them IDs in the following
 ; ranges:
 ;
@@ -18,7 +22,7 @@
 ; More cases can be added in edit_mode_loop - see check_return_key,
 ; check_tab_key, check_delete_key, etc.
 
-; plain
+; key
 CMD_EXECUTE: = $A0
 CMD_TOGGLE_INS_OVER: = $A1
 CMD_TOP_KEY: = $A2
@@ -35,7 +39,7 @@ CMD_RIGHT = $AD
 CMD_DOWN = $AE
 CMD_UP = $AF
 
-; shift+
+; shift+key
 CMD_NEW: = $B0
 CMD_OLD: = $B1
 CMD_UNDO: = $B2
@@ -52,7 +56,7 @@ CMD_LINE_END = $BD
 CMD_SCREEN_DOWN = $BE
 CMD_SCREEN_UP = $BF
 
-; ctrl+
+; ctrl+key
 CMD_MARK: = $C0
 CMD_GOTO_KEY: = $C1
 CMD_SPLIT_STMNT: = $C2
@@ -74,6 +78,90 @@ CMD_LINE_PREV = $CF
 .endif
 
 
+.else
+
+
+; Electron key layout
+;
+; Commands are bound to keys by giving them IDs in the following
+; ranges:
+;
+; $Ax - FUNC + 0-9 ($A0-A9) and (plain) copy ($AB) + cursor (LRDU - $AC-AF)
+; $Bx - FUNC + A-P ($B0-BF)
+; $Cx - FUNC + Q-Z ($C0-C9) and (ignoring quotes) ':;,-./' ($CA-CF)
+;
+; The eletron does not support shift or ctrl with the function, copy or cursor
+; keys so we have to remap things to FUNC + letters.
+;
+; More cases can be added in edit_mode_loop - see check_return_key,
+; check_tab_key, check_delete_key, etc.
+
+; FUNC + copy and cursor keys
+CMD_EXECUTE: = $A0
+CMD_TOGGLE_INS_OVER: = $A1
+CMD_TOP_KEY: = $A2
+CMD_END_KEY: = $A3
+CMD_RENUMBER_KEY: = $A4
+CMD_CONTINUE: = $A5
+CMD_DELETE_EOL: = $A6
+CMD_TOP_SCREEN: = $A7
+CMD_IE: = $A8
+CMD_EXIT: = $A9
+CMD_DELETE_FWDS = $AB
+CMD_LEFT = $AC
+CMD_RIGHT = $AD
+CMD_DOWN = $AE
+CMD_UP = $AF
+
+; FUNC + letters A-Z
+CMD_SWAP_CASE: = $B0
+CMD_NUMBER_KEY: = $B1
+CMD_FORE_KEY := $B2
+CMD_PREV_STMNT = $B3
+CMD_EXTEND_STMNT: = $B4
+CMD_NEXT_STMNT = $B5
+CMD_GOTO_KEY: = $B6
+; $B7 unused
+CMD_tab_key: = $B8
+CMD_JOIN_STMNT: = $B9
+CMD_MARK: = $BA
+CMD_LABEL_KEY: = $BB
+CMD_MODE_KEY: = $BC
+CMD_NEW: = $BD
+CMD_OLD: = $BE
+; $BF unused
+CMD_SCROLL: = $C0
+CMD_ZRUN: = $C1
+CMD_SPLIT_STMNT: = $C2
+CMD_IT: = $C3
+CMD_UNDO: = $C4
+CMD_BACK_KEY := $C5
+CMD_NOSCROLL: = $C6
+; $C7 unused
+CMD_REPEAT: = $C8
+CMD_ZSAVE: = $C9
+
+; FUNC + (ignoring quotes) ':;,-./'
+CMD_SCREEN_UP = $CA
+; $CB used in ORIGINAL_CTRL_UP_DOWN below
+CMD_LINE_START = $CC
+; $CD used in ORIGINAL_CTRL_UP_DOWN below
+CMD_LINE_END = $CE
+CMD_SCREEN_DOWN = $CF
+
+; FUNC + D F
+.if ORIGINAL_CTRL_UP_DOWN
+CMD_SCREEN_TOP = $CD
+CMD_SCREEN_BOTTOM = $CB
+.else
+CMD_LINE_NEXT = $CB
+CMD_LINE_PREV = $CD
+.endif
+
+
+.endif
+
+
 ; numbers outside $A0-$CF are internal numbers for triggering commands and
 ; don't map directly to key codes, so they just need to be unique
 
@@ -88,7 +176,9 @@ CMD_INSERT: = $D7
 CMD_OVERTYPE: = $D8
 CMD_INFO: = $D9
 CMD_goto_line: = $DA
+.if !ELECTRON
 CMD_tab_key: = $DB
+.endif
 CMD_RENUMBER: = $DC
 CMD_LOAD: = $DD
 CMD_APPEND: = $DE

--- a/cmds.s65
+++ b/cmds.s65
@@ -17,26 +17,66 @@
 ;
 ; More cases can be added in edit_mode_loop - see check_return_key,
 ; check_tab_key, check_delete_key, etc.
-;
-; 
 
-CMD_toggle_insert_overtype: = $A1
-CMD_f2_key: = $A3
-CMD_f4_key: = $A4
+; plain
+CMD_EXECUTE: = $A0
+CMD_TOGGLE_INS_OVER: = $A1
+CMD_TOP_KEY: = $A2
+CMD_END_KEY: = $A3
+CMD_RENUMBER_KEY: = $A4
+CMD_CONTINUE: = $A5
+CMD_DELETE_EOL: = $A6
+CMD_TOP_SCREEN: = $A7
 CMD_IE: = $A8
 CMD_EXIT: = $A9
-                
+CMD_DELETE_FWDS = $AB
+CMD_LEFT = $AC
+CMD_RIGHT = $AD
+CMD_DOWN = $AE
+CMD_UP = $AF
+
+; shift+
 CMD_NEW: = $B0
 CMD_OLD: = $B1
-CMD_shift_f2_key: = $B2
-CMD_shift_f3_key: = $B3
-CMD_shift_f4_key: = $B4
-CMD_shift_f5_key: = $B5
-CMD_shift_f6_key: = $B6
-CMD_shift_f7_key: = $B7
+CMD_UNDO: = $B2
+CMD_SWAP_CASE: = $B3
+CMD_EXTEND_STMNT: = $B4
+CMD_MODE_KEY: = $B5
+CMD_LABEL_KEY: = $B6
+CMD_NUMBER_KEY: = $B7
 CMD_IT: = $B8
+CMD_ZSAVE: = $B9
+; unused - $BB
+CMD_LINE_START = $BC
+CMD_LINE_END = $BD
+CMD_SCREEN_DOWN = $BE
+CMD_SCREEN_UP = $BF
+
+; ctrl+
+CMD_MARK: = $C0
+CMD_GOTO_KEY: = $C1
+CMD_SPLIT_STMNT: = $C2
+CMD_JOIN_STMNT: = $C3
+CMD_REPEAT: = $C4
 CMD_SCROLL: = $C5
 CMD_NOSCROLL: = $C6
+CMD_BACK_KEY := $C7
+CMD_FORE_KEY := $C8
+CMD_ZRUN: = $C9
+CMD_PREV_STMNT = $CC
+CMD_NEXT_STMNT = $CD
+.if ORIGINAL_CTRL_UP_DOWN
+CMD_SCREEN_BOTTOM = $CE
+CMD_SCREEN_TOP = $CF
+.else
+CMD_LINE_NEXT = $CE
+CMD_LINE_PREV = $CF
+.endif
+
+
+; numbers outside $A0-$CF are internal numbers for triggering commands and
+; don't map directly to key codes, so they just need to be unique
+
 CMD_RUN: = $D0
 CMD_MODE: = $D1
 CMD_NUMBER: = $D2
@@ -66,9 +106,6 @@ CMD_EDIT: = $E9
 CMD_TOP: = $EA
 CMD_END: = $EB
 CMD_shift_tab_key: = $EC
-CMD_ZSAVE: = $b9
 CMD_IFIND: = $EF
 CMD_ICHANGE: = $F0
 CMD_QICHANGE: = $F1
-CMD_ZRUN: = $c9
-                

--- a/docs/build.md
+++ b/docs/build.md
@@ -10,5 +10,5 @@ Prerequisites:
 To build, type `make`.
 
 The ROM images are written to a folder called `.build`: `basiced.rom`
-and `hibasiced.rom`.
-
+and `hibasiced.rom`.  The Electron ROM images are called
+`elkbasiced.rom` and `elkhibasiced.rom`.

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -157,3 +157,52 @@ Notes:
   slot; when the Tube isn't active, the ROM does basically nothing, so
   when you type `*BE` you'll get The BASIC Editor.
 
+# Electron version
+
+The Electron version is largely identical to the BBC normal version
+but has had some changes to accommodate differences in the Electron's
+display and keyboard capabilities.
+
+When in the editor, insert mode is indicated by a flashing cursor.
+Overwrite mode uses a steady cursor.
+
+Function keys 0-9 do the same thing as they do on the BBC but you
+obviously have to press FUNC + number.  Also note that f0 (execute)
+is at the other end of the row.
+
+SHIFT and CTRL, however, cannot be used with function keys, nor COPY
+and the cursor keys.  Instead, these functions have been remapped to
+FUNC + various letters and punctuation characters:
+
+- A - swap case (SHIFT+f3)
+- B - number (SHIFT+f7)
+- C - foreground (CTRL+f8)
+- D - previous statement (CTRL+left)
+- E - extend statement (SHIFT+f4)
+- F - next statement (CTRL+right)
+- G - goto (CTRL+f1)
+- J - join statements (CTRL+f3)
+- K - mark (CTRL+f0)
+- L - label (SHIFT+f6)
+- M - mode (SHIFT+f5) - currently unused
+- N - new (SHIFT+f0)
+- O - old (SHIFT+f1)
+- Q - scroll on (CTRL+f5)
+- R - ZRUN (CTRL+f9)
+- S - split statement (CTRL+f2)
+- T - insert at top (SHIFT+f8)
+- U - undo (SHIFT+f2)
+- V - background (CTRL+f7)
+- W - scroll off (CTRL+f6)
+- Y - repeat (CTRL+f4)
+- Z - ZSAVE (SHIFT+f9)
+- ,/< - start of line (SHIFT+left)
+- ./> - end of line (SHIFT+right)
+- :/* - screen up (SHIFT+up)
+- (slash)/? - screen down (SHIFT+down)
+- -/= - top of screen (CTRL+up)
+- ;/+ - bottom of screen (CTRL+down)
+
+Note that these shortcuts prevent you from using FUNC + the letter keys to
+obtain the keyword firmkeys that you would normally get in BASIC on the
+Electron.

--- a/mainpart.s65
+++ b/mainpart.s65
@@ -792,7 +792,11 @@ loc_82CB:
                 PHA
                 LDA     cursor_size
                 PHA
+.if !ELECTRON
                 LDA     #0
+.else
+                LDA     #1
+.endif
                 STA     is_insert_mode  ; 0=overtype 1=insert
                 LDA     #$60 ; '`'
                 STA     cursor_size
@@ -4802,11 +4806,12 @@ poll_key:
 ;-------------------------------------------------------------------------
 
 make_cursor_invisible:			
-					
+
+.if !ELECTRON
+
 		LDX	#10
 		LDY	#32
 ; End of function make_cursor_invisible
-
 
 
 ; X = CRTC register
@@ -4831,11 +4836,43 @@ write_crtc:
 		RTS
 ; End of function write_crtc
 
+.else
 
+		LDY #0
+; End of function make_cursor_invisible
+
+
+; Y = VDU 23,1,Y,0;0;0;0;
+
+set_cursor_state:
+
+		PHA			; save A
+		TYA
+		PHA			; save Y
+		LDA #23
+		JSR OSWRCH
+		LDA #1
+		JSR OSWRCH
+		TYA
+		JSR OSWRCH
+		LDY #8
+		LDA #0
+set_cursor_shape_8zeros:
+		JSR OSWRCH
+		DEY
+		BNE set_cursor_shape_8zeros
+		PLA
+		TAY
+		PLA
+		RTS
+
+.endif
 
 
 reset_cursor_shape:			
-					
+
+.if !ELECTRON
+
 		JSR	get_current_mode_in_x
 		LDA	#0
 		LDY	is_insert_mode	; 0=overtype 1=insert
@@ -4859,6 +4896,20 @@ loc_9BE6:
 loc_9BE9:				
 		LDX	#11
 		JMP	write_crtc
+
+.else
+
+		LDY #1	; show cursor
+		JSR set_cursor_state
+
+		LDA is_insert_mode ; 0=overtype 1=insert
+		ORA #2 ; to give 2=steady 3=flashing
+		TAY
+		JMP set_cursor_state
+
+.endif
+
+
 ; End of function reset_cursor_shape
 
 ;-------------------------------------------------------------------------
@@ -6814,7 +6865,11 @@ loc_A5F7:
 		RTS
 
 run_or_exit_command: .proc
+.if !ELECTRON
 		LDA	#0
+.else
+		LDA #1
+.endif
 		STA	is_insert_mode	; 0=overtype 1=insert
 		LDA	#$60 ; '`'
 		STA	cursor_size

--- a/mainpart.s65
+++ b/mainpart.s65
@@ -1093,7 +1093,7 @@ loc_8437:
                 LDA     #226
                 JSR     osbyte_with_y0
 ; Set Ctrl+function keys to produce ASCII $C0...$C9
-                LDX     #$C0 ; '¿'
+                LDX     #$C0 ; 'ÔøΩ'
                 LDA     #227
                 JMP     osbyte_with_y0
 
@@ -1310,7 +1310,7 @@ loc_855A:
 		CMP	(byte_25),Y
 		BNE	loc_8576
 		LDA	byte_35
-		ORA	#$80 ; 'Ä'
+		ORA	#$80 ; 'ÔøΩ'
 		STA	$40,X
 		INX
 		LDA	byte_36
@@ -2956,7 +2956,7 @@ loc_91AA:
 		JMP	loc_912C
 
 loc_91BB:				
-		CMP	#$A7 ; -$59 ;	'ß'
+		CMP	#$A7 ; -$59 ;	'ÔøΩ'
                 beq edit_found_line
                 cmp #13
                 bne loc_91C5
@@ -2965,7 +2965,7 @@ edit_found_line:
 		JMP	loc_9DA8
 
 loc_91C5:				
-		CMP	#$AF ; -$51 ;	'Ø'
+		CMP	#$AF ; -$51 ;	'ÔøΩ'
 		BNE	loc_91E3
 		LDA	byte_3B
 		BNE	loc_91DE
@@ -3691,40 +3691,40 @@ command_jump_table:
                 .command_jump $24,CMD_IE,ie_cmd
                 .command_jump $24,CMD_IT,it_cmd
                 .command_jump 8,$1B,escape_key_command
-                .command_jump 0,CMD_toggle_insert_overtype,toggle_insert_overtype_command
-                .command_jump $19,$A2,top_edit_mode_command
-                .command_jump $19,CMD_f2_key,end_edit_mode_command
-                .command_jump $19,CMD_f4_key,renumber_edit_mode_command
+                .command_jump 0,CMD_TOGGLE_INS_OVER,toggle_insert_overtype_command
+                .command_jump $19,CMD_TOP_KEY,top_edit_mode_command
+                .command_jump $19,CMD_END_KEY,end_edit_mode_command
+                .command_jump $19,CMD_RENUMBER_KEY,renumber_edit_mode_command
                 .command_jump $A,CMD_EXIT,run_or_exit_command
                 .command_jump 2,CMD_NEW,new_command
                 .command_jump 1,CMD_OLD,old_command
-                .command_jump 0,CMD_shift_f2_key,undo_edit_mode_command
-                .command_jump 0,CMD_shift_f4_key,extend_statement_edit_mode_command
-                .command_jump 0,CMD_shift_f3_key,swap_case_edit_mode_command
-                .command_jump $19,$A7,top_of_screen_edit_mode_command
-                .command_jump 0,$A0,execute_edit_mode_command
-                .command_jump 0,$C7,background_edit_mode_command
-                .command_jump 0,$C8,foreground_edit_mode_command
-                .command_jump 0,$A6,delete_to_end_of_line_edit_mode_command
+                .command_jump 0,CMD_UNDO,undo_edit_mode_command
+                .command_jump 0,CMD_EXTEND_STMNT,extend_statement_edit_mode_command
+                .command_jump 0,CMD_SWAP_CASE,swap_case_edit_mode_command
+                .command_jump $19,CMD_TOP_SCREEN,top_of_screen_edit_mode_command
+                .command_jump 0,CMD_EXECUTE,execute_edit_mode_command
+                .command_jump 0,CMD_BACK_KEY,background_edit_mode_command
+                .command_jump 0,CMD_FORE_KEY,foreground_edit_mode_command
+                .command_jump 0,CMD_DELETE_EOL,delete_to_end_of_line_edit_mode_command
                 .command_jump 1,CMD_delete_key,delete_key_command
                 .command_jump 1,CMD_shift_delete_key,loc_AAC8
-                .command_jump 1,$ab,loc_AAC8
-                .command_jump 0,$AC,cursor_left_edit_mode_command
-                .command_jump 0,$AD,cursor_right_edit_mode_command
-                .command_jump 0,$AE,cursor_down_edit_mode_command
-                .command_jump 0,$AF,cursor_up_edit_mode_command
-                .command_jump 0,$BC,shift_cursor_left_edit_mode_command
-                .command_jump 0,$BD,shift_cursor_right_edit_mode_command
-                .command_jump $18,$BE,shift_cursor_down_edit_mode_command
-                .command_jump $18,$BF,shift_cursor_up_edit_mode_command
-                .command_jump 0,$CC,move_to_prev_stmt_edit_mode_command
-                .command_jump 0,$CD,move_to_next_stmt_edit_mode_command
+                .command_jump 1,CMD_DELETE_FWDS,loc_AAC8
+                .command_jump 0,CMD_LEFT,cursor_left_edit_mode_command
+                .command_jump 0,CMD_RIGHT,cursor_right_edit_mode_command
+                .command_jump 0,CMD_DOWN,cursor_down_edit_mode_command
+                .command_jump 0,CMD_UP,cursor_up_edit_mode_command
+                .command_jump 0,CMD_LINE_START,shift_cursor_left_edit_mode_command
+                .command_jump 0,CMD_LINE_END,shift_cursor_right_edit_mode_command
+                .command_jump $18,CMD_SCREEN_DOWN,shift_cursor_down_edit_mode_command
+                .command_jump $18,CMD_SCREEN_UP,shift_cursor_up_edit_mode_command
+                .command_jump 0,CMD_PREV_STMNT,move_to_prev_stmt_edit_mode_command
+                .command_jump 0,CMD_NEXT_STMNT,move_to_next_stmt_edit_mode_command
                 .if ORIGINAL_CTRL_UP_DOWN
-                .command_jump $10,$CE,move_to_bottom_of_screen_edit_mode_command
-                .command_jump $10,$CF,move_to_top_of_screen_edit_mode_command
+                .command_jump $10,CMD_SCREEN_BOTTOM,move_to_bottom_of_screen_edit_mode_command
+                .command_jump $10,CMD_SCREEN_TOP,move_to_top_of_screen_edit_mode_command
                 .else
-                .command_jump $10,$CE,move_to_next_line_edit_mode_command
-                .command_jump $10,$CF,move_to_prev_line_edit_mode_command
+                .command_jump $10,CMD_LINE_NEXT,move_to_next_line_edit_mode_command
+                .command_jump $10,CMD_LINE_PREV,move_to_prev_line_edit_mode_command
                 .endif
                 .command_jump 2,CMD_LOAD,load_command
                 .command_jump 0,CMD_APPEND,append_command
@@ -3744,17 +3744,17 @@ command_jump_table:
                 .command_jump 0,$63,loc_AD39
                 .command_jump 0,$64,loc_AEB9
                 .command_jump 0,$6D,loc_AD39
-                .command_jump 0,$AB,copy_key_edit_mode_command
+                .command_jump 0,CMD_DELETE_FWDS,copy_key_edit_mode_command
                 .command_jump 0,CMD_tab_key,tab_key_command
                 .command_jump 0,CMD_RUN,run_or_exit_command
                 .command_jump 0,CMD_MODE,mode_command
-                .command_jump 0,$C0,mark_edit_mode_command
-                .command_jump $1D,$C1,goto_edit_mode_command
+                .command_jump 0,CMD_MARK,mark_edit_mode_command
+                .command_jump $1D,CMD_GOTO_KEY,goto_edit_mode_command
                 .command_jump $40,CMD_NUMBER,number_command
                 .command_jump $40,CMD_LABEL,label_command
-                .command_jump 0,$C2,split_statement_edit_mode_command
-                .command_jump 1,$C3,join_statements_edit_mode_command
-                .command_jump $21,$C4,repeat_edit_mode_command
+                .command_jump 0,CMD_SPLIT_STMNT,split_statement_edit_mode_command
+                .command_jump 1,CMD_JOIN_STMNT,join_statements_edit_mode_command
+                .command_jump $21,CMD_REPEAT,repeat_edit_mode_command
                 .command_jump 0,CMD_SCROLL,scroll_command
                 .command_jump 0,CMD_NOSCROLL,noscroll_command
                 .command_jump 2,CMD_HELP,help_command
@@ -3763,13 +3763,13 @@ command_jump_table:
                 .command_jump 0,CMD_INSERT,insert_command
                 .command_jump 0,CMD_OVERTYPE,overtype_command
                 .command_jump 2,CMD_INFO,info_command
-                .command_jump $49,CMD_shift_f6_key,label_edit_mode_command
-                .command_jump $49,CMD_shift_f7_key,number_edit_mode_command
+                .command_jump $49,CMD_LABEL_KEY,label_edit_mode_command
+                .command_jump $49,CMD_NUMBER_KEY,number_edit_mode_command
                 .command_jump $14,CMD_goto_line,goto_line_command
                 .command_jump 0,CMD_RENUMBER,renumber_command
                 .command_jump 0,CMD_TAB,tab_command
                 .command_jump 0,CMD_GOTO,goto_command
-                .command_jump 8,$A5,continue_edit_mode_command
+                .command_jump 8,CMD_CONTINUE,continue_edit_mode_command
                 .command_jump 0,CMD_EDIT,find_command
                 .command_jump $14,CMD_TOP,top_command
                 .command_jump $14,CMD_END,end_command
@@ -3780,9 +3780,8 @@ command_jump_table:
                 .command_jump 0,CMD_QICHANGE,qichange_or_ichange_command
                 .command_jump 8,CMD_ZRUN,zrun_command
                 .if ENABLE_DEBUG
-                .command_jump 8,CMD_shift_f5_key,print_debug_stuff_edit_mode_command
+                .command_jump 8,CMD_MODE_KEY,print_debug_stuff_edit_mode_command
                 .endif
-                ; .command_jump 0,$b9,zsave_command
 		.byte $FF
 
 ;-------------------------------------------------------------------------
@@ -4135,7 +4134,7 @@ loc_9821:
 
 loc_9835:				
 		LDA	byte_400
-		CMP	#-5 ; '˚'
+		CMP	#-5 ; 'ÔøΩ'
 		BNE	loc_9840
 
 loc_983C:				
@@ -9373,10 +9372,10 @@ loc_B12E:
 		STA	(byte_27),Y
 		DEY
 		LDA	byte_21
-		AND	#-$40 ;	'¿'
+		AND	#-$40 ;	'ÔøΩ'
 		STA	byte_21
 		LDA	byte_22
-		AND	#-$40 ;	'¿'
+		AND	#-$40 ;	'ÔøΩ'
 		LSR
 		LSR
 		ORA	byte_21
@@ -9441,7 +9440,7 @@ isnumchar:
 		RTS
 ; End of function isnumchar
 
-		.byte  $B1 ; ±
+		.byte  $B1 ; ÔøΩ
 		.byte  $27 ; '
 
 
@@ -9559,7 +9558,7 @@ loc_B207:
 		JMP	sub_B196_scan_line
 
 loc_B210:				
-		JSR	issymchar	; sets C if A is a valid symbol	char (A-Z, a-z,	0-9, _,	£)
+		JSR	issymchar	; sets C if A is a valid symbol	char (A-Z, a-z,	0-9, _,	ÔøΩ)
 		BCC	loc_B228        ;taken if not valid symbol char
 
 loc_B215:				
@@ -9568,7 +9567,7 @@ loc_B215:
 loc_B217:
                 ; find next non-symbol char
 		LDA	(byte_27),Y
-		JSR	issymchar	;sets C if A is a valid symbol	char (A-Z, a-z,	0-9, _,	ú)
+		JSR	issymchar	;sets C if A is a valid symbol	char (A-Z, a-z,	0-9, _,	ÔøΩ)
 		BCC	loc_B207        ;taken if not valid symbol char
 		JSR	increment_27    ;next input char
 		JMP	loc_B217        ;
@@ -9671,7 +9670,7 @@ found_token:
                 ; check if this is actually a variable name
 		LDA	(byte_27),Y ;get input byte
 		JSR	issymchar ; sets C if A is a valid symbol char
-                                  ; (A-Z, a-z, 0-9, _, ú)
+                                  ; (A-Z, a-z, 0-9, _, ÔøΩ)
 		BCS	loc_B215  ;taken if valid symbol char - this
                                   ;is the prefix of a variable name,
                                   ;not a token
@@ -9718,7 +9717,7 @@ loc_B2B2:
 PROC_or_FN_name:				
 		LDA	(byte_27),Y ;get next input byte
 		JSR	issymchar ; sets C if A is a valid symbol char
-                                  ; (A-Z, a-z, 0-9, _, ú)
+                                  ; (A-Z, a-z, 0-9, _, ÔøΩ)
 		BCC	PROC_or_FN_name_done  ;taken if not a valid symbol char
 		JSR	increment_27 ;next input byte
 		JMP	PROC_or_FN_name     ;keep going
@@ -10036,9 +10035,9 @@ loc_B430:
 		LDA	unk_37
 		BNE	loc_B461
 		LDA	(unk_1F),Y
-		CMP	#$f4 ;-$C ; 'Ù' REM
+		CMP	#$f4 ;-$C ; 'ÔøΩ' REM
 		BEQ	loc_B476
-		CMP	#$DC ; -$24 ;	'‹' DATA
+		CMP	#$DC ; -$24 ;	'ÔøΩ' DATA
 		BEQ	loc_B476
 		CMP	#$2A ; '*'
 		BNE	loc_B446
@@ -10054,7 +10053,7 @@ loc_B446:
 loc_B44E:				
 		LDX	#1
 		STX	byte_36
-		CMP	#$8D ; -$73 ;	'ç' line number
+		CMP	#$8D ; -$73 ;	'ÔøΩ' line number
 		BNE	loc_B45A
 		LDX	#4
 		BNE	loc_B463
@@ -10184,7 +10183,7 @@ loc_B4E5:
 		JMP	loc_B4E5
 
 loc_B4EF:				
-		CMP	#$F4 ; -$C ; 'Ù'
+		CMP	#$F4 ; -$C ; 'ÔøΩ'
 		BNE	loc_B52F
 		INY
 
@@ -10297,7 +10296,7 @@ loc_B53E:
 		PLA
 		STA	(unk_1F),Y
 		DEY
-		LDA	#$8d ; -$73 ;	'ç'
+		LDA	#$8d ; -$73 ;	'ÔøΩ'
 		STA	(unk_1F),Y
 		STA	byte_6B3
 		LDA	unk_1E
@@ -10517,7 +10516,7 @@ loc_B6AA:
 
 loc_B6AD:				
 		LDA	(unk_1F),Y
-		CMP	#$8d ; -$73 ;	'ç'
+		CMP	#$8d ; -$73 ;	'ÔøΩ'
 		BNE	loc_B6AA
 		LDA	unk_1F
 		STA	byte_27
@@ -11774,7 +11773,7 @@ loc_BD7B:
 
 sub_BD83:				
 					
-		LDA	#$86 ; -$7A ;	'Ü'
+		LDA	#$86 ; -$7A ;	'ÔøΩ'
 		JSR	OSBYTE
 		LDX	#$15
 		JMP	gotoxy
@@ -11869,7 +11868,7 @@ loc_BDF5:
 		BCS	loc_BE23
 		SEC
 		SBC	#1
-		CMP	#-4 ; '¸'
+		CMP	#-4 ; 'ÔøΩ'
 		BCS	loc_BE23
 		STA	byte_400
 		BCC	loc_BE57
@@ -11885,7 +11884,7 @@ loc_BE09:
 		LDY	unk_6AE
 		BMI	loc_BE2B
 		BCS	loc_BE23
-		CMP	#-4 ; '¸'
+		CMP	#-4 ; 'ÔøΩ'
 		BCC	loc_BE2B
 
 loc_BE23:				

--- a/mainpart.s65
+++ b/mainpart.s65
@@ -208,6 +208,9 @@ aTheBasicEditor_0:
                 .endif
                 .text 0
                 .text VER
+.if ELECTRON
+				.text "E"
+.endif
 .if RELOCATABLE
                 .text "r"
 .endif
@@ -1092,11 +1095,11 @@ loc_8437:
                 LDX     #$A0
                 LDA     #225
                 JSR     osbyte_with_y0
-; Set SHIFT+function keys to produce ASCII $B0...$B9
+; Set SHIFT+function keys (BBC) or FUNC+A-P (Electron) to produce ASCII $B0...$B9
                 LDX     #$B0
                 LDA     #226
                 JSR     osbyte_with_y0
-; Set Ctrl+function keys to produce ASCII $C0...$C9
+; Set Ctrl+function keys (BBC) or FUNC+Q-Z+punctuation (Electron) to produce ASCII $C0...$C9
                 LDX     #$C0 ; '�'
                 LDA     #227
                 JMP     osbyte_with_y0
@@ -3628,11 +3631,20 @@ reset_keys_settings:
 		LDX	#1
 		LDA	#225		; reset	F key status?
 		JSR	osbyte_with_y0
+.if !ELECTRON
 		LDX	#128
 		LDA	#226		; reset	Shift+F	key status?
 		JSR	osbyte_with_y0
 		LDA	#227
 		JMP	osbyte_with_x0_y0
+.else
+		LDX #1
+		LDA #226		; reset FUNC+A-P
+		JSR osbyte_with_y0
+		LDX #1
+		LDA #227		; reset FUNC+Q-Z+punctuation
+		JMP osbyte_with_y0
+.endif
 ; End of function reset_keys_settings
 
 


### PR DESCRIPTION
 Resolves #17 — these are the changes to support running on the Electron.

The first change updates the command keycodes and jump table to be organised more clearly and have a command code for everything.  This is to make the changes to support the Electron keyboard more straightforward and obvious.  This doesn't change anything in terms of what's built.

The changes to support the Electron are then to remove the 6845 register calls in favour of VDU 23.  The Electron doesn't support changing the cursor height, so I've made insert mode flashing and overwrite steady.

Also, the keyboard and OSBYTE 225-228 work differently on the Electron, so you can't have SHIFT/CTRL+fkeys, so I've moved those functions in favour of FUNC+key (where key is a letter or a punctuation symbol).  The keys are documented in the instructions.

I've done quite a bit of testing and so far it's all worked perfectly and I've not had any crashes or aberrations.  There might be something sneaky in there but that will probably only come out when people try using it.

The Electron versions are built as BUILD_TYPE 8 and 9, in addition to the BBC builds.  9 is the HI version but I don't have a Tube (yet) to test this; version 8 works fine, though.

When building the BBC version, despite the changes to the commands table, the output binaries for both the regular and HI versions are identical, so there is absolutely no change to the BBC version (which was my aim).